### PR TITLE
Fix Heroku deploy issues

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -89,7 +89,5 @@ gem 'acts-as-taggable-on', '~> 9.0', '>= 9.0.1'
 
 gem "cloudinary"
 
-gem "dotenv-rails", groups: [:development, :test]
-
 gem "geocoder"
 gem 'noticed'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -183,6 +183,8 @@ GEM
     nio4r (2.5.9)
     nokogiri (1.15.2-arm64-darwin)
       racc (~> 1.4)
+    nokogiri (1.15.2-x86_64-linux)
+      racc (~> 1.4)
     noticed (1.6.3)
       http (>= 4.0.0)
       rails (>= 5.2.0)
@@ -293,6 +295,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
+  x86_64-linux
 
 DEPENDENCIES
   acts-as-taggable-on (~> 9.0, >= 9.0.1)


### PR DESCRIPTION
Duplicate Gem:
The build log mentions that your Gemfile lists the dotenv-rails gem more than once. Having duplicate gems in your Gemfile can cause problems down the line, and it's best practice to only list each gem once.

To resolve this, check your Gemfile and remove any duplicate entries for the dotenv-rails gem.

Unsupported Platform:
The error message also states that your local platform is x86_64-linux, but your Gemfile.lock only supports arm64-darwin-22. This is the underlying architecture of your machine. The Ruby bundle is complaining that it has been packaged on a different architecture (arm64-darwin-22) than what your local environment uses (x86_64-linux).

To resolve this, you need to add your local platform to your Gemfile.lock by running the following command in your terminal: bundle lock --add-platform x86_64-linux
